### PR TITLE
Changed name of Error level

### DIFF
--- a/src/glog.gleam
+++ b/src/glog.gleam
@@ -7,8 +7,7 @@ import gleam/dynamic.{Dynamic}
 import glog/arg.{Args}
 import glog/field.{Field, Fields}
 import glog/level.{
-  Alert, ConfigLevel, Critical, Debug, Emergency, Err, Info, Level, Notice,
-  Warning,
+  Alert, ConfigLevel, Critical, Debug, Emergency, Info, Level, Notice, Warning,
 }
 import gleam/io
 
@@ -226,14 +225,14 @@ pub fn criticalf(logger: Glog, string: String, values: Args) -> Glog {
 ///
 /// Calling this function return a new Glog. Old Glog can still be used.
 pub fn error(logger: Glog, message: String) -> Glog {
-  log(logger, Err, message)
+  log(logger, level.Error, message)
 }
 
 /// Prints Err log with current fields stored and the given message template and values
 ///
 /// Calling this function return a new Glog. Old Glog can still be used.
 pub fn errorf(logger: Glog, string: String, values: Args) -> Glog {
-  logf(logger, Err, string, values)
+  logf(logger, level.Error, string, values)
 }
 
 /// Prints Warning log with current fields stored and the given message

--- a/src/glog/level.gleam
+++ b/src/glog/level.gleam
@@ -33,7 +33,7 @@ pub type Level {
   Emergency
   Alert
   Critical
-  Err
+  Error
   Warning
   Notice
   Info


### PR DESCRIPTION
I found a problem with the error level which was referenced as "Err" in level.gleam. Since the levels are passed to the erlang logger api this caused an exception since it doesn't match the internal name of the error level.

I tested the following:
```gleam
  glog.new()
  |> glog.error("Test")
```

Which caused this exception in the logger:
```
exception error: no function clause matching
                 logger_config:less_or_equal_level(err,5) (logger_config.erl, line 75)
  in function  logger:do_log/3 (logger.erl, line 1087)
  in call from glog:log/3 (build/dev/erlang/glog/_gleam_artefacts/glog.erl, line 161)
  in call from logger_test:main/0 (build/dev/erlang/logger_test/_gleam_artefacts/logger_test.erl, line 64)
```

This patch should fix the problem (with the cost that the Error level now needs an explicit module reference)